### PR TITLE
cleanup(drive): remove policy mutation tools from MCP surface

### DIFF
--- a/agent_layer_test/suite.json
+++ b/agent_layer_test/suite.json
@@ -204,36 +204,6 @@
       ]
     },
     {
-      "id": "13",
-      "name": "Attach a Policy to an Object",
-      "description": "Plan how to attach an access policy to a Drive object.",
-      "success_criteria": [
-        "Ask for object_id and policy_id.",
-        "Plan includes a policy attach action.",
-        "Do not execute tool calls."
-      ],
-      "prompt_variants": [
-        { "id": "a", "prompt": "Attach policy_id 9 to Drive object_id 28." },
-        { "id": "b", "prompt": "Apply an access policy to this folder so downloads are restricted (planning only)." },
-        { "id": "c", "prompt": "I want to apply a policy to a Drive item; I know the policy id and object id." }
-      ]
-    },
-    {
-      "id": "14",
-      "name": "Detach a Policy Attachment",
-      "description": "Plan how to remove a specific policy attachment from a Drive object.",
-      "success_criteria": [
-        "Ask for object_id and attachment_id.",
-        "Plan includes a detach action.",
-        "Do not execute tool calls."
-      ],
-      "prompt_variants": [
-        { "id": "a", "prompt": "Remove policy attachment att-2 from Drive object_id 28." },
-        { "id": "b", "prompt": "Detach a policy from this Drive folder (I have the attachment id)." },
-        { "id": "c", "prompt": "Undo an access policy attachment on a Drive object (planning only)." }
-      ]
-    },
-    {
       "id": "15",
       "name": "List Recent Transfers",
       "description": "Find recent transfers (uploads) and identify a transfer id for follow-up actions.",
@@ -342,8 +312,6 @@
     { "tool_name": "drive_get_drive_download_url", "prompt": "Get a download URL for Drive file object_id 88." },
     { "tool_name": "drive_share_drive_object", "prompt": "Share Drive file object_id 88 with recipient alice@example.com." },
     { "tool_name": "drive_list_object_policy_attachments", "prompt": "List policy attachments for Drive object_id 28." },
-    { "tool_name": "drive_attach_policy_to_object", "prompt": "Attach policy_id 9 to Drive object_id 28." },
-    { "tool_name": "drive_detach_policy_from_object", "prompt": "Detach attachment_id att-2 from Drive object_id 28." },
 
     { "tool_name": "transfers_list_transfers", "prompt": "List transfers (optionally filtered by org_id if I provide it)." },
     { "tool_name": "transfers_get_transfer", "prompt": "Get transfer metadata for transfer_id tid-1." },

--- a/src/stellarbridge_mcp/client.py
+++ b/src/stellarbridge_mcp/client.py
@@ -164,21 +164,6 @@ class StellarBridgeClient:
     def list_policy_attachments(self, object_id: int) -> Any:
         return self._request("GET", f"/objects/{object_id}/policy-attachments")
 
-    def attach_policy(self, object_id: int, policy_id: int) -> Any:
-        raw = self._request(
-            "POST",
-            f"/objects/{object_id}/policy-attachments",
-            json={"policy_id": policy_id, "priority": 0},
-        )
-        if isinstance(raw, dict) and isinstance(raw.get("data"), dict):
-            att = raw["data"].get("attachment")
-            if isinstance(att, dict) and "id" in att:
-                return {"attachmentId": att["id"]}
-        return raw
-
-    def detach_policy(self, object_id: int, attachment_id: str) -> Any:
-        return self._request("DELETE", f"/objects/{object_id}/policy-attachments/{attachment_id}")
-
     # ------------------------------------------------------------------
     # Projects
     # ------------------------------------------------------------------

--- a/src/stellarbridge_mcp/tools/drive.py
+++ b/src/stellarbridge_mcp/tools/drive.py
@@ -225,21 +225,3 @@ def list_object_policy_attachments(
 ) -> Any:
     """List all policies currently attached to a Drive object."""
     return get_client().list_policy_attachments(object_id)
-
-
-@mcp.tool()
-def attach_policy_to_object(
-    object_id: Annotated[int, "ID of the Drive object"],
-    policy_id: Annotated[int, "Numeric access policy ID to attach"],
-) -> Any:
-    """Attach an access-control policy to a Drive file or folder."""
-    return get_client().attach_policy(object_id, policy_id)
-
-
-@mcp.tool()
-def detach_policy_from_object(
-    object_id: Annotated[int, "ID of the Drive object"],
-    attachment_id: Annotated[str, "ID of the policy attachment to remove"],
-) -> Any:
-    """Remove a policy attachment from a Drive file or folder."""
-    return get_client().detach_policy(object_id, attachment_id)

--- a/src/stellarbridge_mcp/tools/transfers.py
+++ b/src/stellarbridge_mcp/tools/transfers.py
@@ -22,6 +22,11 @@ def list_transfers(
 
     Each item includes a transfer id (``tid``) for ``get_transfer`` and related
     tools when you do not already have an id.
+
+    Note: the API enforces unique file key names. If a file is uploaded with a
+    name that already exists, the new file may be renamed (e.g.
+    ``invoice.pdf`` -> ``invoice (1).pdf``). When selecting a transfer by name,
+    verify the exact file name in the list before acting on it.
     """
     return get_client().list_transfers(org_id)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -82,7 +82,6 @@ Use these to validate the MCP server against a **real** Stellarbridge API (stagi
 | `STELLARBRIDGE_TEST_DELETE_OBJECT_ID` | Disposable object ID for `drive_delete_drive_object`. |
 | `STELLARBRIDGE_TEST_FILE_PLACEHOLDER_OBJECT_ID` | File placeholder for upload/complete URL tools (falls back to `STELLARBRIDGE_TEST_OBJECT_ID`). |
 | `STELLARBRIDGE_TEST_DOWNLOAD_OBJECT_ID` | File object for download URL (falls back to `STELLARBRIDGE_TEST_OBJECT_ID`). |
-| `STELLARBRIDGE_TEST_POLICY_ID` / `STELLARBRIDGE_TEST_ATTACHMENT_ID` | Policy attach/detach live tests. |
 | `STELLARBRIDGE_TEST_TRANSFER_ID` | Transfer id (uuid). If unset, obtain a `tid` from MCP tool **`transfers_list_transfers`** (each row has `tid`), or `task live-first-transfer-id`. |
 | `STELLARBRIDGE_TEST_PUBLIC_TRANSFER_ID` | Public transfer id (falls back to `STELLARBRIDGE_TEST_TRANSFER_ID`). |
 | `STELLARBRIDGE_TEST_DELETE_TRANSFER_ID` | Disposable transfer for `transfers_delete_transfer`. |

--- a/tests/integration/mcp_tool_cases.py
+++ b/tests/integration/mcp_tool_cases.py
@@ -28,8 +28,6 @@ EXPECTED_MCP_TOOL_NAMES: frozenset[str] = frozenset(
         "drive_get_drive_download_url",
         "drive_share_drive_object",
         "drive_list_object_policy_attachments",
-        "drive_attach_policy_to_object",
-        "drive_detach_policy_from_object",
         # transfers (upload_transfer_multipart_file: dedicated multipart test)
         "transfers_list_transfers",
         "transfers_get_transfer",
@@ -193,22 +191,6 @@ TOOL_HTTP_CASES: tuple[ToolHttpCase, ...] = (
         None,
         200, [{"policyId": "p1"}],
         [{"policyId": "p1"}],
-    ),
-    ToolHttpCase(
-        "drive_attach_policy_to_object",
-        {"object_id": 16, "policy_id": 9},
-        "POST", "/api/v1/objects/16/policy-attachments",
-        None,
-        200, {"attachmentId": "att-1"},
-        {"attachmentId": "att-1"},
-    ),
-    ToolHttpCase(
-        "drive_detach_policy_from_object",
-        {"object_id": 17, "attachment_id": "att-2"},
-        "DELETE", "/api/v1/objects/17/policy-attachments/att-2",
-        None,
-        204, None,
-        None,
     ),
     ToolHttpCase(
         "transfers_list_transfers",

--- a/tests/integration_live/live_tool_registry.py
+++ b/tests/integration_live/live_tool_registry.py
@@ -272,28 +272,6 @@ def _drive_list_object_policy_attachments(_repo_root: Path) -> tuple[dict[str, A
     return {"object_id": oid}, ""
 
 
-def _drive_attach_policy_to_object(_repo_root: Path) -> tuple[dict[str, Any] | None, str]:
-    r = _require_mutation_allow()
-    if r is not None:
-        return None, r
-    oid = _env_int("STELLARBRIDGE_TEST_OBJECT_ID")
-    policy = _env_int("STELLARBRIDGE_TEST_POLICY_ID")
-    if oid is None or policy is None:
-        return None, "Set STELLARBRIDGE_TEST_OBJECT_ID and STELLARBRIDGE_TEST_POLICY_ID."
-    return {"object_id": oid, "policy_id": policy}, ""
-
-
-def _drive_detach_policy_from_object(_repo_root: Path) -> tuple[dict[str, Any] | None, str]:
-    r = _require_mutation_allow()
-    if r is not None:
-        return None, r
-    oid = _env_int("STELLARBRIDGE_TEST_OBJECT_ID")
-    att = _env_str("STELLARBRIDGE_TEST_ATTACHMENT_ID")
-    if oid is None or not att:
-        return None, "Set STELLARBRIDGE_TEST_OBJECT_ID and STELLARBRIDGE_TEST_ATTACHMENT_ID."
-    return {"object_id": oid, "attachment_id": att}, ""
-
-
 def _transfers_list_transfers(_repo_root: Path) -> tuple[dict[str, Any] | None, str]:
     org = _env_str("STELLARBRIDGE_TEST_ORG_ID")
     if org:
@@ -510,12 +488,10 @@ _LIVE_TOOL_SPECS_RAW: tuple[LiveToolSpec, ...] = (
     LiveToolSpec("audit_get_audit_logs", _audit_get_audit_logs),
     LiveToolSpec("audit_get_audit_logs_for_actor", _audit_get_audit_logs_for_actor),
     LiveToolSpec("audit_get_audit_logs_for_file", _audit_get_audit_logs_for_file),
-    LiveToolSpec("drive_attach_policy_to_object", _drive_attach_policy_to_object),
     LiveToolSpec("drive_complete_drive_upload", _drive_complete_drive_upload),
     LiveToolSpec("drive_create_drive_file_placeholder", _drive_create_drive_file_placeholder),
     LiveToolSpec("drive_create_drive_folder", _drive_create_drive_folder),
     LiveToolSpec("drive_delete_drive_object", _drive_delete_drive_object),
-    LiveToolSpec("drive_detach_policy_from_object", _drive_detach_policy_from_object),
     LiveToolSpec("drive_get_drive_download_url", _drive_get_drive_download_url),
     LiveToolSpec("drive_get_drive_object", _drive_get_drive_object),
     LiveToolSpec("drive_get_drive_upload_url", _drive_get_drive_upload_url),

--- a/tests/integration_live/run_mcp_live_full_workflow.py
+++ b/tests/integration_live/run_mcp_live_full_workflow.py
@@ -699,30 +699,8 @@ async def _run(
 
             steps.append(await _call(session, "drive_list_object_policy_attachments", {"object_id": placeholder_id}))
 
-            # Policy mutation tools are intentionally NOT exercised.
-            # Agents are explicitly banned from mutating policies in the API.
-            if "drive_attach_policy_to_object" in tool_names:
-                steps.append(
-                    ToolStep(
-                        tool_name="drive_attach_policy_to_object",
-                        arguments={"object_id": placeholder_id, "policy_id": "<not exercised>"},
-                        status="SKIP",
-                        note="Not exercised: policy mutations are banned for agent/API-key workflows.",
-                        parsed_json=None,
-                        raw_text_preview="",
-                    )
-                )
-            if "drive_detach_policy_from_object" in tool_names:
-                steps.append(
-                    ToolStep(
-                        tool_name="drive_detach_policy_from_object",
-                        arguments={"object_id": placeholder_id, "attachment_id": "<not exercised>"},
-                        status="SKIP",
-                        note="Not exercised: policy mutations are banned for agent/API-key workflows.",
-                        parsed_json=None,
-                        raw_text_preview="",
-                    )
-                )
+            # Policy mutation tools (attach/detach) were removed from the MCP surface.
+            # list_object_policy_attachments is tested above.
 
             # Upload URL -> PUT -> complete
             if not _FIXTURE.is_file():

--- a/tests/integration_live/run_mcp_live_retest_blocked_tools.py
+++ b/tests/integration_live/run_mcp_live_retest_blocked_tools.py
@@ -26,9 +26,7 @@ from mcp.client.stdio import StdioServerParameters, stdio_client
 
 
 RETEST_TOOL_NAMES: tuple[str, ...] = (
-    "drive_attach_policy_to_object",
     "drive_delete_drive_object",
-    "drive_detach_policy_from_object",
     "drive_get_drive_download_url",
     "drive_share_drive_object",
     "projects_delete_project",
@@ -387,14 +385,6 @@ def _write_report(*, path: Path, steps: list[StepResult]) -> None:
     by_tool: dict[str, StepResult] = {s.tool_name: s for s in steps}
     notes: dict[str, str] = {}
     # Static skip notes for tools that require out-of-band IDs.
-    notes.setdefault(
-        "drive_attach_policy_to_object",
-        "Requires STELLARBRIDGE_TEST_POLICY_ID and object permissions; not exercised in this workflow.",
-    )
-    notes.setdefault(
-        "drive_detach_policy_from_object",
-        "Requires STELLARBRIDGE_TEST_ATTACHMENT_ID; not exercised in this workflow.",
-    )
     notes.setdefault(
         "projects_delete_project",
         "Requires an empty disposable project id; not exercised in this workflow.",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -169,21 +169,6 @@ class TestRequestBehavior:
         }
 
 
-class TestPolicyAttachments:
-    def test_attach_policy_uses_snake_case(self, httpx_mock: pytest_httpx.HTTPXMock):
-        httpx_mock.add_response(
-            method="POST",
-            url="http://localhost:8080/api/v1/objects/12/policy-attachments",
-            json={"data": {"attachment": {"id": 1}}, "error": None},
-        )
-        client = StellarBridgeClient()
-        client.attach_policy(12, 5)
-
-        req = httpx_mock.get_requests()[0]
-        body = json.loads(req.content.decode("utf-8"))
-        assert body == {"policy_id": 5, "priority": 0}
-
-
 class TestUploadComplete:
     def test_complete_upload_sends_bucket_etag_size(self, httpx_mock: pytest_httpx.HTTPXMock):
         httpx_mock.add_response(

--- a/tests/test_drive.py
+++ b/tests/test_drive.py
@@ -18,8 +18,6 @@ from stellarbridge_mcp.tools.drive import (
     get_drive_download_url,
     share_drive_object,
     list_object_policy_attachments,
-    attach_policy_to_object,
-    detach_policy_from_object,
 )
 
 
@@ -206,13 +204,3 @@ class TestPolicyAttachments:
         mock_client.list_policy_attachments.return_value = []
         list_object_policy_attachments(object_id=5)
         mock_client.list_policy_attachments.assert_called_once_with(5)
-
-    def test_attach_policy(self, mock_client):
-        mock_client.attach_policy.return_value = {"attachmentId": 1}
-        attach_policy_to_object(object_id=5, policy_id=42)
-        mock_client.attach_policy.assert_called_once_with(5, 42)
-
-    def test_detach_policy(self, mock_client):
-        mock_client.detach_policy.return_value = None
-        detach_policy_from_object(object_id=5, attachment_id="att-1")
-        mock_client.detach_policy.assert_called_once_with(5, "att-1")


### PR DESCRIPTION
## Summary

Removes  and  from the MCP tool surface. These tools are not accessible to API-key callers (return 422) and agents are explicitly banned from policy mutations.

The read-only  remains available.

## What changed

- **Source:** Removed two tools from  and two client methods from 
- **Tests:** Updated all test layers (unit, integration mock, live registry, agent layer)
- **Docs:** Removed stale env vars from 
- **Guidance:** Added concise docstring warning to  about API unique-key enforcement

## Verification

- ============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/mark/code/EpykLab/stllr-mcp
configfile: pyproject.toml
plugins: asyncio-1.3.0, httpx-0.36.0, pytest_httpserver-1.1.5, anyio-4.12.1, langsmith-0.7.22
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 167 items

tests/integration/test_mcp_langgraph_agent.py .                          [  0%]
tests/integration/test_mcp_stdio_all_tools.py .......................... [ 16%]
......                                                                   [ 19%]
tests/integration/test_mcp_stdio_multipart_upload.py .                   [ 20%]
tests/integration/test_mcp_stdio_upload_drive_file_from_path.py .        [ 20%]
tests/integration_live/test_mcp_stdio_live_all_tools.py ssssssssssssssss [ 30%]
sssssssssssssssss                                                        [ 40%]
tests/integration_live/test_mcp_stdio_live_smoke.py s                    [ 41%]
tests/test_audit.py ............                                         [ 48%]
tests/test_client.py ...............                                     [ 57%]
tests/test_config.py ....                                                [ 59%]
tests/test_drive.py ..................                                   [ 70%]
tests/test_live_tool_registry_coverage.py ..                             [ 71%]
tests/test_mcp_stdio_helpers.py ......                                   [ 75%]
tests/test_multipart_s3_upload.py .................                      [ 85%]
tests/test_projects.py .....                                             [ 88%]
tests/test_requests.py ....                                              [ 91%]
tests/test_server.py ..                                                  [ 92%]
tests/test_transfers.py .............                                    [100%]

======================= 133 passed, 34 skipped in 28.92s ======================= — 133 passed, 34 skipped, 0 failures
- No remaining references to removed tools in Python files
-  remains fully tested

## Rationale

- These tools return 422 for API-key callers (no agent access)
- Agents are explicitly banned from mutating policies
- The tools are not usable in the current authentication model

## What remains

-  (read-only) stays in the tool surface
- Concise docstring warning added to  about API unique-key enforcement ( -> )